### PR TITLE
Add basic Next.js todo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Todo App
+
+This is a simple Todo application built with Next.js and TypeScript.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+Visit `http://localhost:3000` to see the app.

--- a/components/TodoItem.tsx
+++ b/components/TodoItem.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface TodoItemProps {
+  todo: string;
+  completed: boolean;
+  onToggle: () => void;
+}
+
+export const TodoItem: React.FC<TodoItemProps> = ({ todo, completed, onToggle }) => {
+  return (
+    <li onClick={onToggle} style={{ textDecoration: completed ? 'line-through' : 'none', cursor: 'pointer' }}>
+      {todo}
+    </li>
+  );
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,11 +1,21 @@
 {
   "name": "codex-gpt",
   "version": "1.0.0",
-  "main": "index.js",
+  "private": true,
   "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
-  "license": "ISC",
-  "description": ""
+  "dependencies": {
+    "next": "13.4.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.1.0",
+    "@types/react": "18.0.28",
+    "typescript": "5.0.4"
+  }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { TodoItem } from '../components/TodoItem';
+
+interface Todo {
+  text: string;
+  completed: boolean;
+}
+
+export default function Home() {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [input, setInput] = useState('');
+
+  const addTodo = () => {
+    if (!input.trim()) return;
+    setTodos([...todos, { text: input.trim(), completed: false }]);
+    setInput('');
+  };
+
+  const toggleTodo = (index: number) => {
+    setTodos(todos.map((todo, i) => i === index ? { ...todo, completed: !todo.completed } : todo));
+  };
+
+  return (
+    <div style={{ maxWidth: 600, margin: '2rem auto', padding: '0 1rem' }}>
+      <h1>Todo App</h1>
+      <div>
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && addTodo()}
+          placeholder="Add todo"
+        />
+        <button onClick={addTodo}>Add</button>
+      </div>
+      <ul>
+        {todos.map((todo, index) => (
+          <TodoItem
+            key={index}
+            todo={todo.text}
+            completed={todo.completed}
+            onToggle={() => toggleTodo(index)}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,12 @@
+body {
+  font-family: sans-serif;
+}
+
+ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+li {
+  margin: 0.25rem 0;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- setup Next.js + TypeScript configuration
- implement simple todo list with add and toggle functionality
- add styling and README instructions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842e174dd2483239aabf260587eeacc