### PR TITLE
Add GitHub Pages docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ npm run dev
 ```
 
 Visit `http://localhost:3000` to see the app.
+
+## GitHub Pages
+
+A simple static page is provided under the `docs/` folder. To publish it on GitHub Pages:
+
+1. Push this repository to GitHub.
+2. In the repository settings, enable **GitHub Pages** and choose the `main` branch and `docs/` folder as the source.
+3. Save the settings and your page will be available at `https://<username>.github.io/<repository-name>/`.
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sample GitHub Page</title>
+  <style>
+    body { font-family: sans-serif; padding: 2rem; }
+    h1 { color: #333; }
+  </style>
+</head>
+<body>
+  <h1>Hello from GitHub Pages</h1>
+  <p>This is a mock web page served using GitHub Pages.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple HTML page under `docs/`
- document how to enable GitHub Pages for this repo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842e315875883238b37c514f9b901ad