### PR TITLE
Add dark mode toggle

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { TodoItem } from '../components/TodoItem';
 
 interface Todo {
@@ -9,6 +9,11 @@ interface Todo {
 export default function Home() {
   const [todos, setTodos] = useState<Todo[]>([]);
   const [input, setInput] = useState('');
+  const [darkMode, setDarkMode] = useState(false);
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', darkMode);
+  }, [darkMode]);
 
   const addTodo = () => {
     if (!input.trim()) return;
@@ -23,6 +28,9 @@ export default function Home() {
   return (
     <div style={{ maxWidth: 600, margin: '2rem auto', padding: '0 1rem' }}>
       <h1>Todo App</h1>
+      <button onClick={() => setDarkMode(!darkMode)} style={{ marginBottom: '1rem' }}>
+        Toggle {darkMode ? 'Light' : 'Dark'} Mode
+      </button>
       <div>
         <input
           value={input}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,18 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+}
+
 body {
   font-family: sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  transition: background-color 0.3s, color 0.3s;
+}
+
+body.dark {
+  --bg-color: #121212;
+  --text-color: #ffffff;
 }
 
 ul {


### PR DESCRIPTION
## Summary
- enable dark mode via CSS variables in `globals.css`
- add toggle button with state management in `index.tsx`

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e865609483238cfb7eb1229d7030