### PR TITLE
Add persistent todos with localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a simple Todo application built with Next.js and TypeScript.
 
+Todos are persisted in your browser's local storage so you won't lose them on refresh.
+
 ## Development
 
 ```bash

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,6 +12,21 @@ export default function Home() {
   const [darkMode, setDarkMode] = useState(false);
 
   useEffect(() => {
+    const stored = localStorage.getItem('todos');
+    if (stored) {
+      try {
+        setTodos(JSON.parse(stored));
+      } catch {
+        // ignore parsing errors
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('todos', JSON.stringify(todos));
+  }, [todos]);
+
+  useEffect(() => {
     document.body.classList.toggle('dark', darkMode);
   }, [darkMode]);
 


### PR DESCRIPTION
## Summary
- persist todo state in the browser using `localStorage`
- mention persistence in README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e92d046483238924beb2a87c5097